### PR TITLE
Use relative URLs

### DIFF
--- a/templates/scripts.ejs
+++ b/templates/scripts.ejs
@@ -1,3 +1,3 @@
-<script src="/static/plugins/ep_embedmedia/static/js/html4-defs.js"></script>
-<script src="/static/plugins/ep_embedmedia/static/js/html-sanitizer.js"></script>
-<script src="/static/plugins/ep_embedmedia/static/js/main.js"></script>
+<script src="../static/plugins/ep_embedmedia/static/js/html4-defs.js"></script>
+<script src="../static/plugins/ep_embedmedia/static/js/html-sanitizer.js"></script>
+<script src="../static/plugins/ep_embedmedia/static/js/main.js"></script>

--- a/templates/styles.ejs
+++ b/templates/styles.ejs
@@ -1,1 +1,1 @@
-<link rel="stylesheet" href="/static/plugins/ep_embedmedia/static/css/main.css" type="text/css" />
+<link rel="stylesheet" href="../static/plugins/ep_embedmedia/static/css/main.css" type="text/css" />


### PR DESCRIPTION
Absolute URLs break users that serve Etherpad from a subdirectory.

Fixes #3 

@lisandi Please test this:

```shell
cd /path/to/etherpad-lite
npm i --no-save --legacy-peer-deps ether/ep_embedmedia#rhansen-relative-links
```