### PR TITLE
fix: use data-l10n-attr for editbar button to silence html10n errors (#11)

### DIFF
--- a/static/tests/backend/specs/l10n_template.js
+++ b/static/tests/backend/specs/l10n_template.js
@@ -1,0 +1,41 @@
+'use strict';
+
+const assert = require('assert').strict;
+const fs = require('fs');
+const path = require('path');
+
+const pluginRoot = path.resolve(__dirname, '..', '..', '..', '..');
+const editbarPath = path.join(pluginRoot, 'templates', 'editbarButtons.ejs');
+
+describe(__filename, function () {
+  it('editbar button does not attach data-l10n-id to elements with child content (#11)',
+      function () {
+        // html10n emits
+        //   "Unexpected error: could not translate element content for key ..."
+        // when an element has a `data-l10n-id` that replaces its text content
+        // *and* it has structural child elements. Every `data-l10n-id` in this
+        // template must therefore either live on a leaf element with no child
+        // nodes, or be paired with `data-l10n-attr` so the translation targets
+        // an attribute (e.g. `title`, `aria-label`) rather than innerHTML.
+        const src = fs.readFileSync(editbarPath, 'utf8');
+        const tagRe = /<([a-zA-Z][a-zA-Z0-9]*)([^>]*\bdata-l10n-id="[^"]+"[^>]*)>/g;
+        const matches = [];
+        let m;
+        while ((m = tagRe.exec(src)) !== null) matches.push({tag: m[1], attrs: m[2], index: m.index});
+        assert(matches.length > 0, 'expected at least one data-l10n-id tag in editbarButtons.ejs');
+        for (const match of matches) {
+          const hasL10nAttr = /data-l10n-attr="[^"]+"/.test(match.attrs);
+          if (hasL10nAttr) continue;
+          // Element translates innerHTML -> must not contain any child tags.
+          // Find the index of the matching closing tag and inspect what's in between.
+          const open = src.indexOf('>', match.index) + 1;
+          const closeRe = new RegExp(`</${match.tag}\\s*>`, 'g');
+          closeRe.lastIndex = open;
+          const close = closeRe.exec(src);
+          assert(close, `unterminated <${match.tag}> in editbarButtons.ejs`);
+          const body = src.slice(open, close.index);
+          assert(!/<[a-zA-Z]/.test(body),
+              `<${match.tag}> has data-l10n-id replacing innerHTML but contains child elements: ${body}`);
+        }
+      });
+});

--- a/templates/editbarButtons.ejs
+++ b/templates/editbarButtons.ejs
@@ -1,5 +1,5 @@
-<li id="insertEmbedMedia" data-l10n-id="ep_embedmedia.embed">
-  <a title="Embed Media" data-l10n-id="ep_embedmedia.embed">
-        <button class="buttonicon buttonicon-align-left buttonicon-embed-media" data-align="0" aria-label="Embed Media"></button>
+<li id="insertEmbedMedia">
+  <a data-l10n-id="ep_embedmedia.embed" data-l10n-attr="title" title="Embed Media">
+    <button class="buttonicon buttonicon-align-left buttonicon-embed-media" data-align="0" aria-label="Embed Media" data-l10n-id="ep_embedmedia.embed" data-l10n-attr="aria-label"></button>
   </a>
 </li>


### PR DESCRIPTION
Fixes #11. html10n logs 'Unexpected error: could not translate element content for key ep_embedmedia.embed' because the editbar template puts data-l10n-id on the <li> and <a>, both of which contain structural children. Move translation onto the title attribute of <a> and aria-label of <button> via data-l10n-attr. Adds a backend spec that fails if any content-replacing data-l10n-id in editbarButtons.ejs lands on an element with child tags.