### PR TITLE
a11y: flatten interactive nesting (restore localized aria-label)

### DIFF
--- a/templates/editbarButtons.ejs
+++ b/templates/editbarButtons.ejs
@@ -1,5 +1,7 @@
-<li id="insertEmbedMedia">
-  <a data-l10n-id="ep_embedmedia.embed" data-l10n-attr="title" title="Embed Media">
-    <button class="buttonicon buttonicon-align-left buttonicon-embed-media" data-align="0" data-l10n-id="ep_embedmedia.embed"></button>
-  </a>
+<li id="insertEmbedMedia" data-type="button" data-key="embedMedia">
+  <a class="buttonicon buttonicon-align-left buttonicon-embed-media"
+     role="button" tabindex="0"
+     data-align="0"
+     data-l10n-id="ep_embedmedia.embed"
+     title="Embed Media"></a>
 </li>


### PR DESCRIPTION
## Summary

Flattens nested toolbar markup to a single `<a role="button" tabindex="0">` carrying the icon classes. With no element children (or with a recognized attribute suffix in `data-l10n-id`), etherpad's html10n auto-populates `aria-label` from the localized string per `html10n.ts:665-678`.

**Why this PR exists:** the earlier Phase 3a sweep removed hardcoded `aria-label="…"` on toolbar buttons that have element children (`<span>`/`<button>`) and a `data-l10n-id` without a recognized attribute suffix (`.title`/`.alt`/`.value`/`.placeholder`). For those elements, html10n skips its auto-population path, so they ended up with no accessible name. Flattening the structure makes the auto-population fire.